### PR TITLE
make shebang line more cross platform by using env bash, make istio version check less tedious to maintain, drop repo check

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,8 @@ __Environment Variables:__
 - `NUM_NS`: The number of namespaced vegeta instances, defaults to 1 with a maximum of 25.
 - `ROLLOUT_TIMEOUT`: The amount of time to wait for each vegeta deployment to rollout, defaults to 5m for 5-minutes.
 
-- `ISTIO_VERSION`: The version of Istio to install. Supported options are "1.22.1" (default) and "1.22.1-patch0-solo".
-- `ISTIO_REPO`: The repo to use for pulling Istio container images. Supported options are "docker.io/istio" (default)
-and "us-docker.pkg.dev/gloo-mesh/istio-a9ee4fe9f69a".
+- `ISTIO_VERSION`: The version of Istio to install. Supported versions as 1.22.1 and above, and 1.23 and above.
+- `ISTIO_REPO`: The repo to use for pulling Istio container images. The default is "docker.io/istio".
 - `ROLLOUT_TIMEOUT`: A time unit, e.g. 1s, 2m, 3h, to wait for Istio deployment roll-outs to complete. Defaults to "5m".
 
 ## Update the Test App

--- a/scripts/create-cluster.sh
+++ b/scripts/create-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/delete.sh
+++ b/scripts/delete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/latency-report.sh
+++ b/scripts/latency-report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The number of namespaces used to run the test app or load generators.
 NUM_NS=${NUM_NS:-"1"}

--- a/scripts/loadgen-config-report.sh
+++ b/scripts/loadgen-config-report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if file_name argument is provided
 if [ -z "$1" ]; then

--- a/scripts/node-pod-resource-utilization.sh
+++ b/scripts/node-pod-resource-utilization.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if file_name argument is provided
 if [ -z "$1" ]; then

--- a/scripts/run-all-reports.sh
+++ b/scripts/run-all-reports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/run-all.sh
+++ b/scripts/run-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/scale.sh
+++ b/scripts/scale.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/uninstall-istio.sh
+++ b/scripts/uninstall-istio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/update-app.sh
+++ b/scripts/update-app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/update-loadgen.sh
+++ b/scripts/update-loadgen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/waypoint-envoy-stats-report.sh
+++ b/scripts/waypoint-envoy-stats-report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if file_name argument is provided
 if [ -z "$1" ]; then


### PR DESCRIPTION
Macs tend to have bash be in differing spots, especially some devs who want to substitute in a newer version. Use /usr/bin/env bash to basically use the bash defined by the environment.

Don't make it so we have to define specific Istio versions to support. We know we *should* support anything newer than 1.22.1 and 1.23.0, so block based on that. We shouldn't break in newer versions, in theory.

Drop the repo check. The script should be able to handle any hub used especially so it can be picked up and used by the Istio build pipeline which will need to set this to its private image repos.

Since I was editing install-istio.sh, I noticed some comments ended with a period and others did not.. the driver for consistency in me couldn't not fix this in this file. 🤣 